### PR TITLE
Add pegoat-authenticode-nested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,3 +70,13 @@ add_custom_command(
   COMMAND
   powershell -ExecutionPolicy Bypass -File sign.ps1 $<TARGET_FILE:pegoat-authenticode>
 )
+
+add_executable(pegoat-authenticode-nested goat.cpp)
+add_custom_command(
+  TARGET
+  POST_BUILD
+  pegoat-authenticode-nested
+  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+  COMMAND
+  powershell -ExecutionPolicy Bypass -File sign-nested.ps1 $<TARGET_FILE:pegoat-authenticode-nested>
+)

--- a/sign-nested.ps1
+++ b/sign-nested.ps1
@@ -1,0 +1,30 @@
+New-SelfSignedCertificate `
+  -DnsName "contact@trailofbits.com" `
+  -HashAlgorithm SHA1 `
+  -Type CodeSigning `
+  -CertStoreLocation `
+  cert:\CurrentUser\My
+
+New-SelfSignedCertificate `
+  -DnsName "contact@trailofbits.com" `
+  -HashAlgorithm SHA256 `
+  -Type CodeSigning `
+  -CertStoreLocation `
+  cert:\CurrentUser\My
+
+Export-Certificate `
+  -Cert (Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert)[0] `
+  -FilePath code_signing_1.crt
+
+Export-Certificate `
+  -Cert (Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert)[1] `
+  -FilePath code_signing_2.crt
+
+signtool.exe sign `
+  /f code_signing_1.crt `
+  $args[0]
+
+signtool.exe sign `
+  /f code_signing_2.crt `
+  /as `
+  $args[0]


### PR DESCRIPTION
Like pegoat-authenticode, except that the embedded Authenticode signature
contains a nested signature. The SHA256 signature should be nested inside
the SHA1 one.

See https://github.com/trailofbits/uthenticode/pull/31.